### PR TITLE
Add game_changer to gameplay types

### DIFF
--- a/src/api/card/card-gameplay.types.ts
+++ b/src/api/card/card-gameplay.types.ts
@@ -75,6 +75,7 @@ interface GameplayCard {
 	colors?: Nullable<Color[]>;
 	defense?: Nullable<string>;
 	edhrec_rank?: Nullable<number>;
+	game_changer?: Nullable<boolean>;
 	hand_modifier?: Nullable<string>;
 	keywords: string[];
 	legalities: Legalities;


### PR DESCRIPTION
game_changer is available on the Scryfall API and just needs to be added to GameplayCard for it to be usable in this package