### PR TITLE
Added 'cmc' to Symbology type

### DIFF
--- a/src/api/symbology/symbology.types.ts
+++ b/src/api/symbology/symbology.types.ts
@@ -14,6 +14,7 @@ interface ManaCost {
 
 interface Symbology {
 	appears_in_mana_costs: boolean;
+	cmc: number;
 	colors: Color[];
 	english: string;
 	funny: boolean;


### PR DESCRIPTION
Added the 'cmc' property to the Symbology type, this property is already available in the Scryfall API: [https://scryfall.com/docs/api/card-symbols/all](https://scryfall.com/docs/api/card-symbols/all)